### PR TITLE
main: Disable WSearch on SSD too

### DIFF
--- a/MakeWindowsGreatAgain_1.0.1-RELEASE/main.ps1
+++ b/MakeWindowsGreatAgain_1.0.1-RELEASE/main.ps1
@@ -539,7 +539,7 @@ function Optimize-ServicesRunning() {
     )
 
     $IsSystemDriveSSD = $(Get-OSDriveType) -eq "SSD"
-    $EnableServicesOnSSD = @("SysMain", "WSearch")
+    $EnableServicesOnSSD = @("SysMain")
 
     # Services which will be totally disabled
     $ServicesToDisabled = @(


### PR DESCRIPTION
* Search/Indexing are causing old 100% cpu/ssd usage on some old devices.
