### PR TITLE
hard.ps1: Do not touch `EventLog`

### DIFF
--- a/MakeWindowsGreatAgain/files/hard.ps1
+++ b/MakeWindowsGreatAgain/files/hard.ps1
@@ -813,6 +813,7 @@ function Optimize-ServicesRunning() {
     Write-Title -Text "Services tweaks"
     Write-Section -Text "Disabling services from Windows"
 
+    Set-ServiceStartup -Manual -Services $ServicesToManual
     If ($Revert) {
         Write-Status -Types "*", "Service" -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $CustomMessage = { "Resetting $Service ($((Get-Service $Service).DisplayName)) as 'Manual' on Startup ..." }
@@ -832,8 +833,6 @@ function Optimize-ServicesRunning() {
         $CustomMessage = { "The $Service ($((Get-Service $Service).DisplayName)) service works better in 'Automatic' mode on Windows 11 ..." }
         Set-ServiceStartup -Automatic -Services $EnableServicesOnWindows11 -CustomMessage $CustomMessage
     }
-
-    Set-ServiceStartup -Manual -Services $ServicesToManual
 }
 
 function Main() {


### PR DESCRIPTION
 * Apparently, this breaks even further the RPC system, for example; when trying to re-enable the Windows Search service, it throws an "1722" error.

 * Re-enabling it back resolves such issues, but nonetheless, this service is helpful to everyone considering it maintains the "Windows Event Log" application.

Change-Id: I0fd70ebf62f2120d4c85d0c36ba82efe4ecf430e