### PR TITLE
hard.ps1: Remove extraneous `{`

### DIFF
--- a/MakeWindowsGreatAgain/files/hard.ps1
+++ b/MakeWindowsGreatAgain/files/hard.ps1
@@ -840,7 +840,7 @@ function Main() {
 }
 
 Main
-}
+
 else {
     Write-Output "Useless services will not be disabled."
 }


### PR DESCRIPTION
 * This change was introduced in commit 7dd3b59858a5b0ffda5d7cefc34dc61582f07110 (fixed explorer crash) and was preventing the script to continue executing when  pressing any available mode.

Change-Id: I3c53b418a5d6483bd89bd8ba03f79fd9533562b0