### PR TITLE
hard.ps1, soft.ps1: Do not set `ndu` to manual

### DIFF
--- a/MakeWindowsGreatAgain/files/hard.ps1
+++ b/MakeWindowsGreatAgain/files/hard.ps1
@@ -745,7 +745,6 @@ function Optimize-ServicesRunning() {
         "FontCache"                      # DEFAULT: Automatic | Windows Font Cache
         "iphlpsvc"                       # DEFAULT: Automatic | IP Helper Service (IPv6 (6to4, ISATAP, Port Proxy and Teredo) and IP-HTTPS)
         "lmhosts"                        # DEFAULT: Manual    | TCP/IP NetBIOS Helper
-        "ndu"                            # DEFAULT: Automatic | Windows Network Data Usage Monitoring Driver (Shows network usage per-process on Task Manager)
         "wuauserv"                       # DEFAULT: Automatic | Windows Update
         "UsoSvc"                         # DEFAULT: Automatic | Update Orchestrator Service (Manages the download and installation of Windows updates)
         #"NetTcpPortSharing"             # DEFAULT: Disabled  | Net.Tcp Port Sharing Service

--- a/MakeWindowsGreatAgain/files/soft.ps1
+++ b/MakeWindowsGreatAgain/files/soft.ps1
@@ -573,7 +573,6 @@ function Optimize-ServicesRunning() {
         "FontCache"                      # DEFAULT: Automatic | Windows Font Cache
         "iphlpsvc"                       # DEFAULT: Automatic | IP Helper Service (IPv6 (6to4, ISATAP, Port Proxy and Teredo) and IP-HTTPS)
         "lmhosts"                        # DEFAULT: Manual    | TCP/IP NetBIOS Helper
-        "ndu"                            # DEFAULT: Automatic | Windows Network Data Usage Monitoring Driver (Shows network usage per-process on Task Manager)
         "wuauserv"                       # DEFAULT: Automatic | Windows Update
         "UsoSvc"                         # DEFAULT: Automatic | Update Orchestrator Service (Manages the download and installation of Windows updates)
         #"NetTcpPortSharing"             # DEFAULT: Disabled  | Net.Tcp Port Sharing Service


### PR DESCRIPTION
 * This slows down the process of closing Task Manager... for some reason. Happens on both Windows 10 (LTSC) and Windows 11.

Change-Id: I4e67bcc3259567375ab36fa2dfd5fb1aeff1b32a