### PR TITLE
hard.ps1, soft.ps1: Remove unnecesary Spotify packages

### DIFF
--- a/MakeWindowsGreatAgain/files/hard.ps1
+++ b/MakeWindowsGreatAgain/files/hard.ps1
@@ -142,9 +142,7 @@ if ($confirm -eq "y") {
             # [DIY] Common Streaming services
     
             "*Netflix*"                        # Netflix
-            "*SpotifyMusic*"                   # Spotify
             "*Spotify*"
-            "*SpotifyAB.SpotifyMusic*"         # dunno why I put 3 spotify packages but maybe one will work"
         )
         foreach ($App in $AppXApps) {
             Write-Verbose -Message ('Removing Package {0}' -f $App)

--- a/MakeWindowsGreatAgain/files/soft.ps1
+++ b/MakeWindowsGreatAgain/files/soft.ps1
@@ -130,9 +130,7 @@ if ($confirm -eq "y") {
             # [DIY] Common Streaming services
     
             "*Netflix*"                        # Netflix
-            "*SpotifyMusic*"                   # Spotify
-            "*Spotify*"
-            "*SpotifyAB.SpotifyMusic*"         # dunno why I put 3 spotify packages but maybe one will work"
+            "*Spotify*"                        # Spotify
         )
         foreach ($App in $AppXApps) {
             Write-Verbose -Message ('Removing Package {0}' -f $App)


### PR DESCRIPTION
 * Considering we are already targetting all packages that matches with *Spotify*, this also includes 'SpotifyMusic' and 'SpotifyAB.SpotifyMusic'.

Change-Id: I11e829ba18aca3e13e0e961c6546f8447138149f